### PR TITLE
Reduce resource usage and some cleanup

### DIFF
--- a/ovll.json
+++ b/ovll.json
@@ -3,7 +3,7 @@
 	"title_id":	"0x010000000007E51A",
 	"title_id_range_min":	"0x010000000007E51A",
 	"title_id_range_max":	"0x010000000007E51A",
-	"main_thread_stack_size":	"0x100000",
+	"main_thread_stack_size":	"0x10000",
 	"main_thread_priority":	49,
 	"default_cpu_id":	3,
 	"process_category":	0,


### PR DESCRIPTION
-33% less heap (from 0x600000 to 0x400000)
-93.75% less stack (from 0x100000 to 0x10000)
-initialize sm before requesting a pmshell session
-use raw fs calls as opposed to stdio

All the overlays I tested so far work fine. (sysmodules, sys-clk, edizon, status-monitor, the examples and my own stuff)