### PR TITLE
Update for latest libnx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ BUILD		:=	build
 SOURCES		:=	source
 DATA		:=	data
 INCLUDES	:=	include
-APP_VERSION	:=	1.0.6
+APP_VERSION	:=	1.0.7
 
 ifeq ($(RELEASE),)
 	APP_VERSION	:=	$(APP_VERSION)-$(shell git describe --dirty --always)

--- a/source/main.c
+++ b/source/main.c
@@ -338,7 +338,7 @@ void loadNro(void)
 
     memset(__stack_top - STACK_SIZE, 0, STACK_SIZE);
 
-    extern NORETURN void nroEntrypointTrampoline(u64 entries_ptr, u64 handle, u64 entrypoint);
+    extern NX_NORETURN void nroEntrypointTrampoline(u64 entries_ptr, u64 handle, u64 entrypoint);
     nroEntrypointTrampoline((u64) entries, -1, entrypoint);
 }
 


### PR DESCRIPTION
Fixes compilation with latest libnx, see: https://github.com/switchbrew/libnx/pull/632

The makefile was updated to match the latest tagged released: https://github.com/WerWolv/nx-ovlloader/releases/tag/v1.0.7