### PR TITLE
update for new DebugFlags capability semantics

### DIFF
--- a/ovll.json
+++ b/ovll.json
@@ -165,8 +165,9 @@
 		}, {
 			"type":	"debug_flags",
 			"value":	{
-				"allow_debug":	false,
-				"force_debug":	true
+				"allow_debug":		false,
+				"force_debug_prod":	false,
+				"force_debug":		true
 			}
 		}]
 }


### PR DESCRIPTION
19.0.0 introduced breaking change to debug flags, now "force_debug" place in npdm was taken by "force_debug_prod", and "force_debug" has new bit. So currently all overlays using svcDebug cannot use them anymore from 19.0.0 in the way it worked pre-19.0.0
And it's not possible to compile it with newest npdmtool without flag this PR introduces. 

https://github.com/switchbrew/switch-tools/pull/47/files#diff-9f3c59f905c898fd301e331fe69d8972b9da0b5b85407dd4b18b37581a1411ebL565

```diff
- desc = (allow_debug & 1) | ((force_debug & 1) << 1);
+ desc = (allow_debug & 1) | ((force_debug_prod & 1) << 1) | ((force_debug & 1) << 2);
```

For recompilation it is required to use updated `switch-tools` from devkitpro, at least `1.13.0-1`

After recompiling it, force_debug will work properly only on Atmosphere 1.8.0 onward